### PR TITLE
Set user directory for openoffice processes

### DIFF
--- a/core/modules/core/src/com/haulmont/yarg/formatters/impl/doc/connector/OOServer.java
+++ b/core/modules/core/src/com/haulmont/yarg/formatters/impl/doc/connector/OOServer.java
@@ -16,8 +16,12 @@
 
 package com.haulmont.yarg.formatters.impl.doc.connector;
 
+import com.google.common.collect.Lists;
 import com.sun.star.comp.helper.BootstrapException;
 import com.sun.star.lib.util.NativeLibraryLoader;
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -57,9 +61,11 @@ public class OOServer {
     /**
      * The options for starting the OOo server.
      */
-    private List oooOptions;
+    private List<String> oooOptions;
 
     private ProcessManager processManager;
+
+    protected OfficeIntegration officeIntegration;
 
     /**
      * Constructs an OOo server which uses the folder of the OOo installation
@@ -69,13 +75,15 @@ public class OOServer {
      * @param oooExecFolder The folder of the OOo installation containing the soffice executable
      * @param oooOptions    The list of options
      */
-    public OOServer(String oooExecFolder, List oooOptions, String host, int port, ProcessManager processManager) {
+    public OOServer(String oooExecFolder, List<String> oooOptions, String host, int port,
+                    ProcessManager processManager, OfficeIntegration officeIntegration) {
         this.oooProcess = null;
         this.oooExecFolder = oooExecFolder;
         this.host = host;
         this.port = port;
         this.oooOptions = oooOptions;
         this.processManager = processManager;
+        this.officeIntegration = officeIntegration;
     }
 
     /**
@@ -103,23 +111,30 @@ public class OOServer {
         if (fOffice == null)
             throw new BootstrapException("no office executable found!");
 
-        // create call with arguments
-        int arguments = (oooOptions != null) ? oooOptions.size() + 1 : 1;
-        arguments++;
-        String[] oooCommand = new String[arguments];
-        oooCommand[0] = fOffice.getPath();
+        List<String> argumentsList = Lists.newLinkedList();
+        argumentsList.add(fOffice.getPath());
 
-        for (int i = 0; i < oooOptions.size(); i++) {
-            oooCommand[i + 1] = (String) oooOptions.get(i);
+        if (CollectionUtils.isNotEmpty(oooOptions))
+            argumentsList.addAll(oooOptions);
+
+        String instanceProfilePath = getInstanceProfilePath();
+        if (StringUtils.isNotBlank(instanceProfilePath)) {
+            prepareInstanceProfileDir();
+            argumentsList.add("-env:UserInstallation=" + toUrl(new File(instanceProfilePath)));
         }
-
-        oooCommand[arguments - 1] = oooAcceptOption;
+        argumentsList.add(oooAcceptOption);
 
         // start office process
-        oooProcess = Runtime.getRuntime().exec(oooCommand);
+        oooProcess = Runtime.getRuntime().exec(argumentsList.toArray(new String[0]));
 
         pipe(oooProcess.getInputStream(), System.out, "CO> ");
         pipe(oooProcess.getErrorStream(), System.err, "CE> ");
+    }
+
+    public String toUrl(File file) {
+        String path = file.toURI().getRawPath();
+        String url = path.startsWith("//") ? "file:" + path : "file://" + path;
+        return url.endsWith("/") ? url.substring(0, url.length() - 1) : url;
     }
 
     /**
@@ -134,6 +149,7 @@ public class OOServer {
             List<Long> pids = processManager.findPid(host, port);
             processManager.kill(oooProcess, pids);
             oooProcess = null;
+            deleteProfileDir();
         }
     }
 
@@ -176,5 +192,41 @@ public class OOServer {
         options.add("-headless");
 
         return options;
+    }
+
+    protected void prepareInstanceProfileDir() {
+        String instanceProfilePath = getInstanceProfilePath();
+        if (StringUtils.isNotBlank(instanceProfilePath)) {
+            File instanceProfileDir = new File(instanceProfilePath);
+            if (instanceProfileDir.exists()) {
+                log.debug(String.format("OpenOffice server profile dir '%s' already exists; deleting", instanceProfileDir));
+                deleteProfileDir();
+            }
+        }
+    }
+
+    protected void deleteProfileDir() {
+        String instanceProfilePath = getInstanceProfilePath();
+        if (StringUtils.isNotBlank(instanceProfilePath)) {
+            File instanceProfileDir = new File(instanceProfilePath);
+            try {
+                FileUtils.deleteDirectory(instanceProfileDir);
+            } catch (IOException ioException) {
+                File oldProfileDir = new File(instanceProfileDir.getParentFile(),
+                        instanceProfileDir.getName() + ".old." + System.currentTimeMillis());
+                if (instanceProfileDir.renameTo(oldProfileDir)) {
+                    log.warn("could not delete profileDir: " + ioException.getMessage() + "; renamed it to " + oldProfileDir);
+                } else {
+                    log.error("could not delete profileDir: " + ioException.getMessage());
+                }
+            }
+        }
+    }
+
+    protected String getInstanceProfilePath() {
+        if (StringUtils.isBlank(officeIntegration.getTemporaryDirPath()))
+            return "";
+
+        return officeIntegration.getTemporaryDirPath() + String.format(".ooserver_%s_%s", host, port);
     }
 }

--- a/core/modules/core/src/com/haulmont/yarg/formatters/impl/doc/connector/OfficeConnection.java
+++ b/core/modules/core/src/com/haulmont/yarg/formatters/impl/doc/connector/OfficeConnection.java
@@ -45,7 +45,8 @@ public class OfficeConnection {
     public OfficeConnection(String openOfficePath, Integer port, ProcessManager processManager, OfficeIntegration officeIntegration) {
         this.port = port;
         this.officeIntegration = officeIntegration;
-        this.oooServer = new OOServer(openOfficePath, OOServer.getDefaultOOoOptions(), "localhost", port, processManager);
+        this.oooServer = new OOServer(openOfficePath, OOServer.getDefaultOOoOptions(),
+                "localhost", port, processManager, officeIntegration);
         this.bsc = new BootstrapSocketConnector(oooServer);
         this.openOfficePath = openOfficePath;
     }


### PR DESCRIPTION
Currently integration starts single openoffice process because -env:UserInstallation parameter isn't set. Setting this parameter allows us to start multiple openoffice processes each with separate port. 

Directories for the processes are created in the OfficeIntegration#temporaryDirPath folder. If temporary directory isn't set, parameter won't be used.

Process directories named as ".ooserver_${host}_${port}" for example - ".ooserver_localhost_8100".

Also this pull request contains commit which adds sl4j logging  which is useful during openoffice problems debugging:
https://github.com/cuba-platform/yarg/commit/bdee7e7819f0b0ef46e872c0607bc5820f68a9b2

