### PR TITLE
Fix retry mechanism for the DocFormatter and PdfConverter

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -246,6 +246,7 @@ configure(core) {
         compile(group: "com.jayway.jsonpath", name: "json-path", version: "2.1.0")
 
         testCompile(group: 'junit', name: 'junit', version: '4.5')
+        testCompile group: 'org.mockito', name: 'mockito-core', version: '3.2.4'
         testCompile(group: 'org.hsqldb', name: 'hsqldb', version: '2.3.3')
     }
 

--- a/core/modules/core/src/com/haulmont/yarg/formatters/impl/doc/connector/OfficeIntegration.java
+++ b/core/modules/core/src/com/haulmont/yarg/formatters/impl/doc/connector/OfficeIntegration.java
@@ -18,7 +18,6 @@ package com.haulmont.yarg.formatters.impl.doc.connector;
 import com.haulmont.yarg.exception.OpenOfficeException;
 import com.sun.star.comp.helper.BootstrapException;
 
-import java.lang.RuntimeException;
 import java.util.Set;
 import java.util.concurrent.*;
 
@@ -31,8 +30,9 @@ public class OfficeIntegration implements OfficeIntegrationAPI {
     protected String openOfficePath;
     protected String temporaryDirPath;
     protected Integer[] openOfficePorts;
-    protected Integer timeoutInSeconds = 60;
-    protected int countOfRetry = 2;
+    protected Integer timeoutInSeconds = DEFAULT_TIMEOUT;
+    protected int countOfRetry = DEFAULT_RETRY_COUNT;
+    protected int retryIntervalMs = DEFAULT_RETRY_INTERVAL;
     protected Boolean displayDeviceAvailable = false;
 
     public OfficeIntegration(String openOfficePath, Integer... ports) {
@@ -56,6 +56,14 @@ public class OfficeIntegration implements OfficeIntegrationAPI {
 
     public void setCountOfRetry(int countOfRetry) {
         this.countOfRetry = countOfRetry;
+    }
+
+    public int getRetryIntervalMs() {
+        return retryIntervalMs;
+    }
+
+    public void setRetryIntervalMs(int retryIntervalMs) {
+        this.retryIntervalMs = retryIntervalMs;
     }
 
     public String getTemporaryDirPath() {

--- a/core/modules/core/src/com/haulmont/yarg/formatters/impl/doc/connector/OfficeIntegrationAPI.java
+++ b/core/modules/core/src/com/haulmont/yarg/formatters/impl/doc/connector/OfficeIntegrationAPI.java
@@ -17,11 +17,18 @@
 package com.haulmont.yarg.formatters.impl.doc.connector;
 
 public interface OfficeIntegrationAPI {
+
+    int DEFAULT_RETRY_COUNT = 2;
+    int DEFAULT_RETRY_INTERVAL = 1000;
+    int DEFAULT_TIMEOUT = 60;
+
     String getTemporaryDirPath();
 
     Integer getTimeoutInSeconds();
 
     int getCountOfRetry();
+
+    int getRetryIntervalMs();
 
     Boolean isDisplayDeviceAvailable();
 

--- a/core/modules/core/test/smoketest/DocSpecificTest.java
+++ b/core/modules/core/test/smoketest/DocSpecificTest.java
@@ -3,7 +3,12 @@ package smoketest;
 import com.haulmont.yarg.formatters.ReportFormatter;
 import com.haulmont.yarg.formatters.factory.DefaultFormatterFactory;
 import com.haulmont.yarg.formatters.factory.FormatterFactoryInput;
+import com.haulmont.yarg.formatters.impl.DocFormatter;
 import com.haulmont.yarg.formatters.impl.doc.connector.OfficeIntegration;
+import com.haulmont.yarg.formatters.impl.doc.connector.OfficeIntegrationAPI;
+import com.haulmont.yarg.formatters.impl.doc.connector.OfficeTask;
+import com.haulmont.yarg.formatters.impl.xls.PdfConverter;
+import com.haulmont.yarg.formatters.impl.xls.PdfConverterImpl;
 import com.haulmont.yarg.structure.BandData;
 import com.haulmont.yarg.structure.BandOrientation;
 import com.haulmont.yarg.structure.ReportFieldFormat;
@@ -20,11 +25,15 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.concurrent.CountDownLatch;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.*;
+
 /**
  * @author degtyarjov
  * @version $Id$
  */
-public class DocSpecificTest extends AbstractFormatSpecificTest{
+public class DocSpecificTest extends AbstractFormatSpecificTest {
     @Test
     public void testTableOdt() throws Exception {
         BandData root = new BandData("Root");
@@ -182,4 +191,38 @@ public class DocSpecificTest extends AbstractFormatSpecificTest{
         System.out.println();
     }
 
+    @Test
+    public void testRetryCount() throws Exception {
+        BandData root = createRootBand();
+        FormatterFactoryInput formatterFactoryInput = new FormatterFactoryInput("doc", root,
+                new ReportTemplateImpl("", "./modules/core/test/smoketest/test.doc",
+                        "./modules/core/test/smoketest/test.doc", ReportOutputType.doc), null);
+        OfficeIntegrationAPI officeIntegrationApiMock = createOfficeIntegrationApiMock(5);
+        DocFormatter docFormatter = new DocFormatter(formatterFactoryInput, officeIntegrationApiMock);
+
+        // Check that in case of exception 'runTaskWithTimeout' will execute exactly retriesCount + 1 times
+        try {
+            docFormatter.renderDocument();
+        } catch (Exception e) {
+            verify(officeIntegrationApiMock, times(6))
+                    .runTaskWithTimeout((OfficeTask) any(), anyInt());
+        }
+
+        officeIntegrationApiMock = createOfficeIntegrationApiMock(4);
+        PdfConverterImpl pdfConverter = new PdfConverterImpl(officeIntegrationApiMock);
+        try {
+            pdfConverter.convertToPdf(PdfConverter.FileType.DOCUMENT, null, null);
+        } catch (Exception e) {
+            verify(officeIntegrationApiMock, times(5))
+                    .runTaskWithTimeout((OfficeTask) any(), anyInt());
+        }
+    }
+
+    protected OfficeIntegrationAPI createOfficeIntegrationApiMock(int retryCount) {
+        OfficeIntegrationAPI mOfficeIntegrationApi = mock(OfficeIntegrationAPI.class);
+        doThrow(RuntimeException.class).when(mOfficeIntegrationApi).runTaskWithTimeout((OfficeTask) any(), anyInt());
+        when(mOfficeIntegrationApi.getCountOfRetry()).thenReturn(retryCount);
+        when(mOfficeIntegrationApi.getRetryIntervalMs()).thenReturn(300);
+        return mOfficeIntegrationApi;
+    }
 }


### PR DESCRIPTION
Fixed retry functionality in case of openoffice process failure.
- Before fix property 'countOfRetry' didn't do anything, only one retry was performing
- Added 'retryIntervalMs' property to the OfficeIntegration class (can be set in the bean definition). Default value is 1 second. Retry interval for example needed if all ports are currently busy: without this interval all attempts would immediately end.


