### PR TITLE
Update OOServer.java

### DIFF
--- a/core/modules/core/src/com/haulmont/yarg/formatters/impl/doc/connector/OOServer.java
+++ b/core/modules/core/src/com/haulmont/yarg/formatters/impl/doc/connector/OOServer.java
@@ -183,13 +183,13 @@ public class OOServer {
 
         ArrayList<String> options = new ArrayList<String>();
 
-        options.add("-nologo");
-        options.add("-nodefault");
-        options.add("-norestore");
-        options.add("-nocrashreport");
-        options.add("-nolockcheck");
-        options.add("-nofirststartwizard");
-        options.add("-headless");
+        options.add("--nologo");
+        options.add("--nodefault");
+        options.add("--norestore");
+        options.add("--nocrashreport");
+        options.add("--nolockcheck");
+        options.add("--nofirststartwizard");
+        options.add("--headless");
 
         return options;
     }


### PR DESCRIPTION
-nologo is deprecated.  Use --nologo instead.
-nodefault is deprecated.  Use --nodefault instead.
-norestore is deprecated.  Use --norestore instead.
-nolockcheck is deprecated.  Use --nolockcheck instead.
-nofirststartwizard is deprecated.  Use --nofirststartwizard instead.
-headless is deprecated.  Use --headless instead.