### PR TITLE
use Gradle Daemon

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,10 @@ before_install:
   - (cd core && chmod +x ./gradlew)
 
 install:
-  - (cd core &&./gradlew --no-daemon assemble)
+  - (cd core &&./gradlew assemble)
 
 script:
-  - (cd core &&./gradlew --no-daemon test)
+  - (cd core &&./gradlew test)
 
 cache:
   directories:


### PR DESCRIPTION
[Gradle daemon](https://docs.gradle.org/current/userguide/gradle_daemon.html#header). The Daemon is a long-lived process that help to avoid the cost of JVM startup for every build. Since Gradle 3.0, Gradle daemon is enabled by default. For an older version, you should enable it by setting `org.gradle.daemon=true`.
